### PR TITLE
Fixed URLs for the Opencast repositories

### DIFF
--- a/matterhorn-execute-api/pom.xml
+++ b/matterhorn-execute-api/pom.xml
@@ -80,7 +80,7 @@
     <repository>
       <id>opencast</id>
       <name>Opencast Repo</name>
-      <url>http://repository.opencastproject.org/nexus/content/groups/public</url>
+      <url>http://nexus.opencast.org/nexus/content/groups/public</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
@@ -91,7 +91,7 @@
     <repository>
       <id>opencast.snapshots</id>
       <name>Opencast SNAPSHOTS</name>
-      <url>http://repository.opencastproject.org/nexus/content/groups/public-snapshots</url>
+      <url>http://nexus.opencast.org/nexus/content/groups/public-snapshots</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>

--- a/matterhorn-execute-impl/pom.xml
+++ b/matterhorn-execute-impl/pom.xml
@@ -130,7 +130,7 @@
     <repository>
       <id>opencast</id>
       <name>Opencast Repo</name>
-      <url>http://repository.opencastproject.org/nexus/content/groups/public</url>
+      <url>http://nexus.opencast.org/nexus/content/groups/public</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
@@ -141,7 +141,7 @@
     <repository>
       <id>opencast.snapshots</id>
       <name>Opencast SNAPSHOTS</name>
-      <url>http://repository.opencastproject.org/nexus/content/groups/public-snapshots</url>
+      <url>http://nexus.opencast.org/nexus/content/groups/public-snapshots</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>

--- a/matterhorn-execute-operations/pom.xml
+++ b/matterhorn-execute-operations/pom.xml
@@ -134,7 +134,7 @@
     <repository>
       <id>opencast</id>
       <name>Opencast Repo</name>
-      <url>http://repository.opencastproject.org/nexus/content/groups/public</url>
+      <url>http://nexus.opencast.org/nexus/content/groups/public</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
@@ -145,7 +145,7 @@
     <repository>
       <id>opencast.snapshots</id>
       <name>Opencast SNAPSHOTS</name>
-      <url>http://repository.opencastproject.org/nexus/content/groups/public-snapshots</url>
+      <url>http://nexus.opencast.org/nexus/content/groups/public-snapshots</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>

--- a/matterhorn-execute-remote/pom.xml
+++ b/matterhorn-execute-remote/pom.xml
@@ -90,7 +90,7 @@
     <repository>
       <id>opencast</id>
       <name>Opencast Repo</name>
-      <url>http://repository.opencastproject.org/nexus/content/groups/public</url>
+      <url>http://nexus.opencast.org/nexus/content/groups/public</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
@@ -101,7 +101,7 @@
     <repository>
       <id>opencast.snapshots</id>
       <name>Opencast SNAPSHOTS</name>
-      <url>http://repository.opencastproject.org/nexus/content/groups/public-snapshots</url>
+      <url>http://nexus.opencast.org/nexus/content/groups/public-snapshots</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>


### PR DESCRIPTION
The Opencast project changed its repository host and URL, now it is hosted on nexus.opencast.org .
